### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/cl-authorize-net.asd
+++ b/cl-authorize-net.asd
@@ -1,10 +1,3 @@
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :cl-creditcard.system)
-    (defpackage :cl-creditcard.system
-      (:use :common-lisp :asdf))))
-
-(in-package :cl-creditcard.system)
-
 (defsystem :cl-authorize-net
   :description "library for talking with authorize.net credit card processors."
   :author "<programmers@acceleration.net>"
@@ -19,15 +12,10 @@
 					       (:file "authorize-processor")
 					       (:file "authorize-echeck"))
 				  ))))
-  :depends-on (:cl-creditcard :drakma :alexandria :symbol-munger
-               :split-sequence))
+  :depends-on (:cl-creditcard :drakma :alexandria :symbol-munger :split-sequence)
+  :in-order-to ((test-op (test-op :cl-authorize-net/tests))))
 
-(defmethod asdf:perform ((o asdf:test-op) (c (eql (find-system :cl-authorize-net))))
-  (asdf:load-system :cl-authorize-net-tests)
-  (let ((*package* (find-package :cl-authorize-tests)))
-    (eval (read-from-string "(run-tests :all)"))))
-
-(defsystem :cl-authorize-net-tests
+(defsystem :cl-authorize-net/tests
   :description "Talk to the Authorize.net Payment Processing Software. Test Suite."
   :author "<programmers@acceleration.net>"
   :licence "MIT"
@@ -38,7 +26,8 @@
 	    :components ((:file "packages")
 			 (:file "authorize" )
 			 )))
-  :depends-on (:cl-authorize-net :lisp-unit :alexandria))
+  :depends-on (:cl-authorize-net :lisp-unit :alexandria)
+  :perform (test-op (o c) (symbol-call :lisp-unit :run-tests :all :cl-authorize-tests)))
 
 ;; Copyright (c) 2008 Acceleration.net, Russ Tyndall, Ryan Davis, Nathan Bird
 

--- a/cl-creditcard.asd
+++ b/cl-creditcard.asd
@@ -1,10 +1,3 @@
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :cl-creditcard.system)
-    (defpackage :cl-creditcard.system
-      (:use :common-lisp :asdf))))
-
-(in-package :cl-creditcard.system)
-
 (defsystem :cl-creditcard
   :description "Generic interace library for talking with credit card processors."
   :author "<programmers@acceleration.net>"


### PR DESCRIPTION
ASDF3 recommends declaring a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)
